### PR TITLE
Create DI::timestampStorage after call ContainerBuilder::getByType

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - hhvm-nightly
 
 env:
   - PHP_BIN=php
@@ -15,18 +14,18 @@ env:
 
 matrix:
   allow_failures:
-    - php: 7.0
     - php: hhvm
-    - php: hhvm-nightly
 
   exclude:
     - php: hhvm
       env: PHP_BIN=php-cgi
 
-    - php: hhvm-nightly
-      env: PHP_BIN=php-cgi
+before_install:
+  - if [[ "$TRAVIS_PHP_VERSION" == "hhvm" ]]; then cat tests/php.ini-unix >> /etc/hhvm/php.ini; fi
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-add tests/php.ini-unix; fi
 
 install:
+  - if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then composer config -g disable-tls true; composer config -g secure-http false; fi
   - composer self-update
   - composer install --prefer-source --no-interaction --optimize-autoloader
 

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,5 @@
 	},
 	"autoload-dev": {
 		"classmap": ["tests/CronnerTests/objects"]
-	},
-	"config": {
-		"disable-tls": true
 	}
 }

--- a/tests/CronnerTests/DI/CronnerExtension.phpt
+++ b/tests/CronnerTests/DI/CronnerExtension.phpt
@@ -49,7 +49,7 @@ class CronnerExtensionTest extends \TestCase
 	public function testDefaultConfiguration()
 	{
 		$compiler = $this->compiler;
-		$compiler->compile(array());
+		$compiler->compile();
 
 		$timestampStorage = $compiler->getContainerBuilder()->getDefinition('cronner.timestampStorage');
 		$criticalSection = $compiler->getContainerBuilder()->getDefinition('cronner.criticalSection');
@@ -65,13 +65,16 @@ class CronnerExtensionTest extends \TestCase
 	public function testCompleteConfiguration()
 	{
 		$compiler = $this->compiler;
-		$compiler->compile(array(
-			'cronner' => array(
-				'timestampStorage' => new Nette\DI\Statement('stekycz\Cronner\TimestampStorage\DummyStorage'),
-				'maxExecutionTime' => 120,
-				'criticalSectionTempDir' => '%tempDir%/cronner',
+		$compiler->addConfig(
+			array(
+				'cronner' => array(
+					'timestampStorage' => new Nette\DI\Statement('stekycz\Cronner\TimestampStorage\DummyStorage'),
+					'maxExecutionTime' => 120,
+					'criticalSectionTempDir' => '%tempDir%/cronner',
+				)
 			)
-		));
+		);
+		$compiler->compile();
 
 		$timestampStorage = $compiler->getContainerBuilder()->getDefinition('cronner.timestampStorage');
 		$criticalSection = $compiler->getContainerBuilder()->getDefinition('cronner.criticalSection');


### PR DESCRIPTION
Convert DI registration for Nette 2.4. There are problem call `::getByType` on `ContainerBuilder` with not completely defined service.

Suppressed error:
`Nette\DI\ServiceCreationException: Class and factory are missing in definition of service 'cronner.timestampStorage'.`
