### PR TITLE
Fix duplicate service names with same arguments

### DIFF
--- a/src/Cronner/DI/CronnerExtension.php
+++ b/src/Cronner/DI/CronnerExtension.php
@@ -90,7 +90,7 @@ class CronnerExtension extends CompilerExtension
 
 		Validators::assert($config['tasks'], 'array');
 		foreach ($config['tasks'] as $task) {
-			$def = $container->addDefinition($this->prefix('task.' . md5(Json::encode($task))));
+			$def = $container->addDefinition($this->prefix('task.' . md5(is_string($task) ? $task : sprintf('%s-%s', $task->getEntity(), Json::encode($task)))));
 			list($def->factory) = Compiler::filterArguments([
 				is_string($task) ? new Statement($task) : $task,
 			]);

--- a/tests/CronnerTests/DI/CronnerExtension.phpt
+++ b/tests/CronnerTests/DI/CronnerExtension.phpt
@@ -6,6 +6,7 @@
 
 namespace stekycz\Cronner\tests\DI;
 
+use Nette\Configurator;
 use Nette\DI\Compiler;
 use Nette\DI\Statement;
 use stekycz\CriticalSection\CriticalSection;
@@ -74,6 +75,20 @@ class CronnerExtensionTest extends \TestCase
 		Assert::same(DummyStorage::class, $timestampStorage->getClass());
 		Assert::same(CriticalSection::class, $criticalSection->getClass());
 		Assert::same(Cronner::class, $runner->getClass());
+	}
+
+	public function testRegisterTasks()
+	{
+		\Tester\Helpers::purge(__DIR__ . '/../../tmp/');
+
+		$config = new Configurator();
+		$config->setTempDirectory(__DIR__ . '/../../tmp/');
+		$config->addConfig(__DIR__ . '/../config/config.neon');
+		$container = $config->createContainer();
+
+		$cronner = $container->getByType('stekycz\Cronner\Cronner');
+
+		Assert::same(2, count($cronner->getTasks()));
 	}
 
 }

--- a/tests/CronnerTests/config/config.neon
+++ b/tests/CronnerTests/config/config.neon
@@ -1,0 +1,11 @@
+extensions:
+	cronner: stekycz\Cronner\DI\CronnerExtension
+
+services:
+	fooService: stekycz\Cronner\tests\objects\FooService
+
+
+cronner:
+	tasks:
+		- stekycz\Cronner\tests\objects\SimpleTestObjectWithDependency(@fooService)
+		- stekycz\Cronner\tests\objects\AnotherSimpleTestObjectWithDependency(@fooService)

--- a/tests/CronnerTests/objects/AnotherSimpleTestObjectWithDependency.php
+++ b/tests/CronnerTests/objects/AnotherSimpleTestObjectWithDependency.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace stekycz\Cronner\tests\objects;
+
+use Nette\Object;
+
+class AnotherSimpleTestObjectWithDependency extends Object
+{
+
+	public function __construct(FooService $service)
+	{
+	}
+
+	/**
+	 * @cronner-task
+	 */
+	public function run()
+	{
+	}
+}

--- a/tests/CronnerTests/objects/FooService.php
+++ b/tests/CronnerTests/objects/FooService.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace stekycz\Cronner\tests\objects;
+
+class FooService
+{
+
+	public function __construct()
+	{
+	}
+
+}
+

--- a/tests/CronnerTests/objects/SimpleTestObjectWithDependency.php
+++ b/tests/CronnerTests/objects/SimpleTestObjectWithDependency.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace stekycz\Cronner\tests\objects;
+
+use Nette\Object;
+
+class SimpleTestObjectWithDependency extends Object
+{
+
+	public function __construct(FooService $service)
+	{
+	}
+
+	/**
+	 * @cronner-task
+	 */
+	public function run()
+	{
+	}
+}
+


### PR DESCRIPTION
```
cronner:
    tasks:
        - MyApp\Cronner\Task1(@myService)
        - MyApp\Cronner\Task2(@myService)
```
      
This configuration will generate duplicate service names because the name is generated only from json part ` {"arguments":["@myService"]}` which is the same for both Task definitions. 

So I've updated the service name generation from String or Statement entity + arguments