### PR TITLE
PHP 7.2 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 
 env:
   - PHP_BIN=php

--- a/src/Cronner/Bar/Tasks.php
+++ b/src/Cronner/Bar/Tasks.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace stekycz\Cronner\Bar;
 
-use Nette\Object;
 use stekycz\Cronner\Cronner;
 use Tracy\IBarPanel;
 
-class Tasks extends Object implements IBarPanel
+class Tasks implements IBarPanel
 {
+	use \Nette\SmartObject;
 
 	/**
 	 * @var Cronner

--- a/src/Cronner/Cronner.php
+++ b/src/Cronner/Cronner.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace stekycz\Cronner;
 
 use Exception;
-use Nette\Object;
 use Nette\Reflection\ClassType;
 use Nette\Utils\DateTime;
 use Nette\Utils\Strings;
@@ -23,9 +22,10 @@ use Tracy\Debugger;
  * @method onTaskFinished(Cronner $cronner, Task $task)
  * @method onTaskError(Cronner $cronner, Exception $exception, Task $task)
  */
-class Cronner extends Object
+class Cronner
 {
-
+	use \Nette\SmartObject;
+  
 	/**
 	 * @var callable[]
 	 */

--- a/src/Cronner/Tasks/Parameters.php
+++ b/src/Cronner/Tasks/Parameters.php
@@ -6,12 +6,12 @@ namespace stekycz\Cronner\Tasks;
 
 use DateTime;
 use Nette;
-use Nette\Object;
 use Nette\Reflection\Method;
 use Nette\Utils\Strings;
 
-final class Parameters extends Object
+final class Parameters
 {
+	use \Nette\SmartObject;
 
 	const TASK = 'cronner-task';
 	const PERIOD = 'cronner-period';

--- a/src/Cronner/Tasks/Parser.php
+++ b/src/Cronner/Tasks/Parser.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace stekycz\Cronner\Tasks;
 
-use Nette\Object;
 use Nette\Utils\Strings;
 use stekycz\Cronner\Exceptions\InvalidParameterException;
 
-class Parser extends Object
+class Parser
 {
+	use \Nette\SmartObject;
 
 	/**
 	 * Parses name of cron task.

--- a/src/Cronner/Tasks/Task.php
+++ b/src/Cronner/Tasks/Task.php
@@ -6,13 +6,13 @@ namespace stekycz\Cronner\Tasks;
 
 use DateTime;
 use Nette;
-use Nette\Object;
 use Nette\Reflection\Method;
 use ReflectionClass;
 use stekycz\Cronner\ITimestampStorage;
 
-final class Task extends Object
+final class Task
 {
+	use \Nette\SmartObject;
 
 	/**
 	 * @var object

--- a/src/Cronner/TimestampStorage/DummyStorage.php
+++ b/src/Cronner/TimestampStorage/DummyStorage.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace stekycz\Cronner\TimestampStorage;
 
 use DateTime;
-use Nette\Object;
 use stekycz\Cronner\ITimestampStorage;
 
-class DummyStorage extends Object implements ITimestampStorage
+class DummyStorage implements ITimestampStorage
 {
+	use \Nette\SmartObject;
 
 	/**
 	 * Sets name of current task.

--- a/src/Cronner/TimestampStorage/FileStorage.php
+++ b/src/Cronner/TimestampStorage/FileStorage.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace stekycz\Cronner\TimestampStorage;
 
 use DateTime;
-use Nette\Object;
 use Nette\Utils\FileSystem;
 use Nette\Utils\SafeStream;
 use Nette\Utils\Strings;
@@ -13,8 +12,9 @@ use stekycz\Cronner\Exceptions\EmptyTaskNameException;
 use stekycz\Cronner\Exceptions\InvalidTaskNameException;
 use stekycz\Cronner\ITimestampStorage;
 
-class FileStorage extends Object implements ITimestampStorage
+class FileStorage implements ITimestampStorage
 {
+	use \Nette\SmartObject;
 
 	const DATETIME_FORMAT = 'Y-m-d H:i:s O';
 

--- a/tests/CronnerTests/Cronner.phpt
+++ b/tests/CronnerTests/Cronner.phpt
@@ -10,7 +10,6 @@ namespace stekycz\Cronner\tests;
 
 use Exception;
 use Mockery;
-use Nette\Object;
 use Nette\Utils\DateTime;
 use stdClass;
 use stekycz\CriticalSection\ICriticalSection;
@@ -179,7 +178,7 @@ class CronnerTest extends \TestCase
 	{
 		$now = new DateTime('2013-02-04 09:30:00');
 
-		$logCallback = Mockery::mock(Object::class);
+		$logCallback = Mockery::mock(stdClass::class);
 		$logCallback->shouldReceive('logError')->once()->andReturnUsing( function (Exception $e, Task $task) {
 			Assert::equal('Test 01', $e->getMessage());
 		});

--- a/tests/CronnerTests/Tasks/ParametersParsing.phpt
+++ b/tests/CronnerTests/Tasks/ParametersParsing.phpt
@@ -35,13 +35,13 @@ class ParametersParsingTest extends \TestCase
 	 */
 	public function testParsesTaskSettings(array $expected, string $methodName)
 	{
-		if (!$this->object->getReflection()->hasMethod($methodName)) {
+		if (!(new \Nette\Reflection\ClassType($this->object))->hasMethod($methodName)) {
 			Assert::fail('Tested class does not have method "' . $methodName . '".');
 
 			return;
 		}
 
-		Assert::same($expected, Parameters::parseParameters($this->object->getReflection()->getMethod($methodName)));
+		Assert::same($expected, Parameters::parseParameters((new \Nette\Reflection\ClassType($this->object))->getMethod($methodName)));
 	}
 
 	public function dataProviderParse() : array

--- a/tests/CronnerTests/Tasks/Task.phpt
+++ b/tests/CronnerTests/Tasks/Task.phpt
@@ -58,7 +58,7 @@ class TaskTest extends \TestCase
 		$now = new Nette\Utils\DateTime($now);
 		$lastRunTime = $lastRunTime ? new Nette\Utils\DateTime($lastRunTime) : NULL;
 
-		$method = $this->object->getReflection()->getMethod($methodName);
+		$method = (new \Nette\Reflection\ClassType($this->object))->getMethod($methodName);
 
 		$timestampStorage = Mockery::mock(ITimestampStorage::class);
 		$timestampStorage->shouldReceive("loadLastRunTime")->times($loads)->andReturn($lastRunTime);

--- a/tests/CronnerTests/objects/AnotherSimpleTestObject.php
+++ b/tests/CronnerTests/objects/AnotherSimpleTestObject.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace stekycz\Cronner\tests\objects;
 
-use Nette\Object;
-
-class AnotherSimpleTestObject extends Object
+class AnotherSimpleTestObject
 {
+	use \Nette\SmartObject;
 
 	/**
 	 * @cronner-task Test

--- a/tests/CronnerTests/objects/NextSimpleTestObject.php
+++ b/tests/CronnerTests/objects/NextSimpleTestObject.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace stekycz\Cronner\tests\objects;
 
-use Nette\Object;
-
-class NextSimpleTestObject extends Object
+class NextSimpleTestObject
 {
+	use \Nette\SmartObject;
 
 	/**
 	 * @cronner-task Test

--- a/tests/CronnerTests/objects/SameTaskNameObject.php
+++ b/tests/CronnerTests/objects/SameTaskNameObject.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace stekycz\Cronner\tests\objects;
 
-use Nette\Object;
-
-class SameTaskNameObject extends Object
+class SameTaskNameObject
 {
+	use \Nette\SmartObject;
 
 	/**
 	 * @cronner-task Test

--- a/tests/CronnerTests/objects/TestExceptionObject.php
+++ b/tests/CronnerTests/objects/TestExceptionObject.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace stekycz\Cronner\tests\objects;
 
 use Exception;
-use Nette\Object;
 
-class TestExceptionObject extends Object
+class TestExceptionObject
 {
+	use \Nette\SmartObject;
 
 	/**
 	 * @cronner-task

--- a/tests/CronnerTests/objects/TestObject.php
+++ b/tests/CronnerTests/objects/TestObject.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace stekycz\Cronner\tests\objects;
 
-use Nette\Object;
-
-class TestObject extends Object
+class TestObject
 {
+	use \Nette\SmartObject;
 
 	/**
 	 * @cronner-task


### PR DESCRIPTION
PHP 7.2 does not allow to use Object as class name, any attempt to extend it (Nette\Object here) results in a fatal error. So I used trait Nette\SmartObject instead.
On SmartObject method getReflection is deprecated, so I also changed tests to directly create reflection objects.